### PR TITLE
Fix missing STTP backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val root = (project in file("."))
     name := "http-sample",
     libraryDependencies ++= Seq(
       Libraries.sttp,
-      Libraries.httpCirce
+      Libraries.httpCirce,
+      Libraries.httpClientBackend
     ) ++ Libraries.circe
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   object Libraries {
     val sttp = "com.softwaremill.sttp.client3" %% "core" % "3.8.6"
     val httpCirce = "com.softwaremill.sttp.client3" %% "circe" % "3.8.6"
+    val httpClientBackend = "com.softwaremill.sttp.client3" %% "httpclient-backend" % "3.8.6"
     val circe = Seq(
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
## Summary
- add the httpclient backend dependency for STTP

## Testing
- `sbt test` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68497f2d386c832bbc573001fc63fbd0