### PR TITLE
Add Dockerfile for running sample

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM hseeberger/scala-sbt:11.0.16_1.8.1_2.13.10
+
+WORKDIR /app
+COPY . .
+
+RUN sbt compile
+
+CMD ["sbt", "run"]
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # sttp-sample
+
+## Docker
+A `Dockerfile` is provided to run the sample application.
+
+Build the image:
+```
+docker build -t sttp-sample .
+```
+
+Run the container:
+```
+docker run --rm sttp-sample
+```
+


### PR DESCRIPTION
## Summary
- add a Dockerfile to run the example with sbt
- update README with Docker usage instructions

## Testing
- `sbt -no-colors test` *(fails: `sbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849828f97b4832b8f29e950c3bd09f6