### PR TITLE
Switch Dockerfile to Scala CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM hseeberger/scala-sbt:11.0.16_1.8.1_2.13.10
+FROM virtuslab/scala-cli:latest
 
 WORKDIR /app
+
+# copy sources
 COPY . .
 
-RUN sbt compile
+# pre-compile the project
+RUN scala-cli compile .
 
-CMD ["sbt", "run"]
+# run the application
+ENTRYPOINT ["scala-cli", "run", "."]
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # sttp-sample
 
 ## Docker
-A `Dockerfile` is provided to run the sample application.
+A `Dockerfile` is provided to run the sample application. It uses
+[Scala CLI](https://scala-cli.virtuslab.org/) for building and running the code.
 
 Build the image:
 ```
 docker build -t sttp-sample .
 ```
 
-Run the container:
+Run the container (which executes `scala-cli run .`):
 ```
 docker run --rm sttp-sample
 ```


### PR DESCRIPTION
## Summary
- use virtuslab/scala-cli image in Dockerfile
- compile sources via `scala-cli compile .`
- run the container with `scala-cli run .`
- update README about Scala CLI usage

## Testing
- `scala-cli compile .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499a519710832b9919a357c96228bf