### PR TITLE
Add Scala CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # sttp-sample
 
+## Running with Scala CLI
+
+This project can be executed locally using [Scala CLI](https://scala-cli.virtuslab.org/).
+After installing Scala CLI, run the following command from the project root:
+
+```
+scala-cli run .
+```
+
+This will download the required dependencies and start the application.
+
 ## Docker
 A `Dockerfile` is provided to run the sample application.
 


### PR DESCRIPTION
## Summary
- explain how to run with Scala CLI in README

## Testing
- `scala-cli run .` *(fails: command not found)*
- `sbt compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499a56ec54832b8699d38b52136716